### PR TITLE
Remove rand.Seed

### DIFF
--- a/shippingservice/tracker.go
+++ b/shippingservice/tracker.go
@@ -17,19 +17,10 @@ package shippingservice
 import (
 	"fmt"
 	"math/rand"
-	"time"
 )
-
-// seeded determines if the random number generator is ready.
-var seeded bool = false
 
 // createTrackingID generates a tracking ID.
 func createTrackingID(salt string) string {
-	if !seeded {
-		rand.Seed(time.Now().UnixNano())
-		seeded = true
-	}
-
 	return fmt.Sprintf("%c%c-%d%s-%d%s",
 		getRandomLetterCode(),
 		getRandomLetterCode(),


### PR DESCRIPTION
As of Go 1.20, `rand` is seeded randomly at program startup, `rand.Seed` is deprecated, and there is no reason to call it with a random value. This module already requires Go 1.20. Also, the deleted code had a race condition: `createTrackingID` can be called concurrently, but `seeded` was not protected.